### PR TITLE
Autonmous builder

### DIFF
--- a/src/main/java/frc/actions/runners/ActionQueue.java
+++ b/src/main/java/frc/actions/runners/ActionQueue.java
@@ -8,12 +8,15 @@
 package frc.actions.runners;
 
 import java.util.ArrayDeque;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Queue;
 
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 public class ActionQueue {
+
+	private final List<Actionable> origActions;
 	
 	private final Queue<Actionable> steps;
 	
@@ -21,7 +24,18 @@ public class ActionQueue {
 	
 	public ActionQueue() {
 		steps = new ArrayDeque<Actionable>();
+		origActions = List.of();
 		addAction(new NullAction());
+	}
+
+	public ActionQueue(List<Actionable> actions) {
+		origActions = actions;
+		steps = new ArrayDeque<Actionable>(actions);
+	}
+
+	public void reset() {
+		steps.clear();
+		steps.addAll(origActions);
 	}
 
 	public void clear() {

--- a/src/main/java/frc/actions/runners/ActionQueue.java
+++ b/src/main/java/frc/actions/runners/ActionQueue.java
@@ -20,15 +20,25 @@ public class ActionQueue {
 	
 	private final Queue<Actionable> steps;
 	
+	/** Flag for printing */
 	boolean done = true;
 	
+	/**
+		Making your own ActionQueue manualy is bad and error prone.
+		Please use the Builder
+		@see frc.actions.runners.ActionQueueBuilder
+	**/
+	@Deprecated
 	public ActionQueue() {
 		steps = new ArrayDeque<Actionable>();
 		origActions = List.of();
 		addAction(new NullAction());
 	}
 
-	public ActionQueue(List<Actionable> actions) {
+	/**
+		Package private consstructor used by ActionQueueBuilder
+	**/
+	ActionQueue(List<Actionable> actions) {
 		origActions = actions;
 		steps = new ArrayDeque<Actionable>(actions);
 	}
@@ -38,11 +48,22 @@ public class ActionQueue {
 		steps.addAll(origActions);
 	}
 
+	/**
+		If you created this class with the builder use {@link reset()} 
+		to reset the queue
+	**/
+	@Deprecated
 	public void clear() {
 		steps.clear();
 		addAction(new NullAction());
 	}
 	
+	/**
+		Making your own ActionQueue manualy is bad and error prone.
+		Please use the Builder
+		@see frc.actions.runners.ActionQueueBuilder
+	**/
+	@Deprecated
 	public void addAction(Actionable action) {
 		steps.add(action);
 	}

--- a/src/main/java/frc/actions/runners/ActionQueueBuilder.java
+++ b/src/main/java/frc/actions/runners/ActionQueueBuilder.java
@@ -1,0 +1,34 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.actions.runners;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+
+public class ActionQueueBuilder {
+	
+	private final List<Actionable> steps;
+	
+	public ActionQueueBuilder() {
+		steps = new ArrayList<Actionable>();
+		steps.add(new NullAction());
+	}
+
+	
+	public ActionQueueBuilder add(Actionable action) {
+		steps.add(action);
+		return this;
+	}
+
+	public ActionQueue build() {
+		return new ActionQueue(steps);
+	}
+
+}

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -14,6 +14,7 @@ import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.GenericHID.Hand;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.actions.runners.ActionQueue;
+import frc.actions.runners.ActionQueueBuilder;
 import frc.actions.runners.JoinActions;
 import frc.actions.*;
 import frc.subsystems.Climber;
@@ -66,34 +67,35 @@ public class Robot extends TimedRobot {
     SmartDashboard.putNumber("x degrees off", limelight.targetXAngleFromCenter());
     SmartDashboard.putBoolean("seeing target?", limelight.isTargetSpotted());
   }
+  /**
+    This is the autonomus that will be done
+    Look in autonomu init of it is overridden
+  **/
+  private ActionQueue actionQueue = driveOverLineAuto;
 
-  private final ActionQueue actionQueue = new ActionQueue();
+  private static final ActionQueue driveOverLineAuto = new ActionQueueBuilder()
+    .add(new DriveStraightTime(-0.5, 1.5))
+	.build();
 
-  private static void driveOverLineAuto(ActionQueue actions) {
-    actions.clear();
-    actions.addAction(new DriveStraightTime(-0.5, 1.5));
-  }
-
-  private static void shootBallAuto(ActionQueue actions) {
-    actions.clear();
-    actions.addAction(new Aim());
-    actions.addAction(new Conveyor(1, .75));
-    actions.addAction(new StartShooter(1));
-    actions.addAction(new FeedBall());
-    actions.addAction(new FeedBall());
-    actions.addAction(new FeedBall());
-    actions.addAction(new StopShooter());
-  }
+  private static final ActionQueue shootBallAuto = new ActionQueueBuilder()
+    .add(new Aim())
+    .add(new Conveyor(1, .75))
+    .add(new StartShooter(1))
+    .add(new FeedBall())
+    .add(new FeedBall())
+    .add(new FeedBall())
+    .add(new StopShooter())
+	.build();
 
   @Override
   public void autonomousInit() {
-    actionQueue.clear();
-    //actionQueue.addAction(new JoinActions(new Wait(5), new DriveStraightTime(.25, 2)));
-    //actionQueue.addAction(new DriveStraightTime(.25,3));
-    //actionQueue.addAction(new DriveStraightTime(.5, 3));
-    //loadBallsAuto(actionQueue);
-    driveOverLineAuto(actionQueue);
-    //shootBallAuto(actionQueue);
+    actionQueue.reset();
+
+    //actionQueue = new actionQueueBuilder().add(new JoinActions(new Wait(5), new DriveStraightTime(.25, 2)));
+    //.add(new DriveStraightTime(.25,3))
+    //.add(new DriveStraightTime(.5, 3))
+    //.build();
+
     limelight.setPipeline(Limelight.PIPELINE_DRIVER_CAM);
     limelight.setLedMode(Limelight.LED_DEFAULT_TO_PIPELINE);
     limelight.setDriverCamMode(false);

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -273,7 +273,7 @@ public class Robot extends TimedRobot {
       }
       if (xboxcontroller.getBButton()) {
         collector.runFrontWheels(-.25);
-        SmartDashboard.putString("MotorsTest", "runotherth9ingageaefawef");
+        SmartDashboard.putString("MotorsTest", "runotherthing");
       } else {
         collector.runFrontWheels(0);
       }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -128,7 +128,7 @@ public class Robot extends TimedRobot {
     SmartDashboard.putString("RobotState", "TeleopEnabled");
   }
 
-  private final ActionQueue teleopActions = new ActionQueue();
+  private final ActionQueue teleopActions = shootBallAuto;
   private boolean teleopShooting = false;
 
   @Override
@@ -136,7 +136,7 @@ public class Robot extends TimedRobot {
 
     if (limelight.isTargetSpotted() && teleopShooting) {
       teleopShooting = false;
-      shootBallAuto(teleopActions);
+      teleopActions.reset();
     }
     if (!teleopShooting && xboxcontroller.getAButtonPressed() && limelight.isTargetSpotted()) {
       teleopShooting = true;

--- a/src/main/java/frc/subsystems/Drive.java
+++ b/src/main/java/frc/subsystems/Drive.java
@@ -116,7 +116,7 @@ public class Drive {
         runFrontRight(right);
     }
 
-    /** Run the back left moter at the given speed */
+    /** Run the back left motor at the given speed */
     public void runBackLeft(double speed) {
         backLeft.set(ControlMode.PercentOutput, speed);
     }


### PR DESCRIPTION
The old API is big bad. How it works is you give actions to the queue and when the queue is done executing is throws them away. You need to repopulate the queue with new object each time it runs. This weird mutation is fine for competition because the code is only run once but there is much testing done.If you restart auto while is is working autonomous ends up in a invalid state. 

This patch uses the Builder Patten™, deprecates the mutating APIs and adds a quirky reset method to the stuff so that mistakes are less.